### PR TITLE
Minor enhancement for PowerShell script and gitignore file

### DIFF
--- a/.github/workflows/build_workspace.yml
+++ b/.github/workflows/build_workspace.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-18.04
           - windows-2019
         toolchain:
           - stable

--- a/.github/workflows/build_workspace.yml
+++ b/.github/workflows/build_workspace.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - windows-latest
+          - windows-2019
         toolchain:
           - stable
           - nightly

--- a/.github/workflows/build_workspace.yml
+++ b/.github/workflows/build_workspace.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - windows-2019
         toolchain:
           - stable

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ Cargo.lock
 # Editor configurations
 .idea/
 .vscode/
+
+# Downloaded artifacts
+VapourSynth**.7z
+
+# Generated files
+utfile

--- a/.scripts/vapoursynth-install.sh
+++ b/.scripts/vapoursynth-install.sh
@@ -19,7 +19,7 @@ apt-get install -y build-essential autoconf libtool pkg-config python3-pip && pi
 # Install zimg (from source)
 download_and_build https://github.com/sekrit-twc/zimg/archive/release-2.9.3.tar.gz zimg-release-2.9.3
 # Install vapoursynth (from source)
-download_and_build https://github.com/vapoursynth/vapoursynth/archive/R47.2.tar.gz vapoursynth-R47.2
+download_and_build https://github.com/vapoursynth/vapoursynth/archive/2f0a78495608424019b7a85510699ef68d8484c2.tar.gz vapoursynth-R52
 # Fix vapoursynth (native) python path
 PYTHON3_LOCAL_LIB_PATH=$(echo /usr/local/lib/python3.*)
 ln -s $PYTHON3_LOCAL_LIB_PATH/site-packages/vapoursynth.so $PYTHON3_LOCAL_LIB_PATH/dist-packages/vapoursynth.so

--- a/.scripts/vapoursynth-install.sh
+++ b/.scripts/vapoursynth-install.sh
@@ -19,7 +19,7 @@ apt-get install -y build-essential autoconf libtool pkg-config python3-pip && pi
 # Install zimg (from source)
 download_and_build https://github.com/sekrit-twc/zimg/archive/release-2.9.3.tar.gz zimg-release-2.9.3
 # Install vapoursynth (from source)
-download_and_build https://github.com/vapoursynth/vapoursynth/archive/2f0a78495608424019b7a85510699ef68d8484c2.tar.gz 2f0a78495608424019b7a85510699ef68d8484c2
+download_and_build https://github.com/vapoursynth/vapoursynth/archive/2f0a78495608424019b7a85510699ef68d8484c2.tar.gz vapoursynth-2f0a78495608424019b7a85510699ef68d8484c2
 # Fix vapoursynth (native) python path
 PYTHON3_LOCAL_LIB_PATH=$(echo /usr/local/lib/python3.*)
 ln -s $PYTHON3_LOCAL_LIB_PATH/site-packages/vapoursynth.so $PYTHON3_LOCAL_LIB_PATH/dist-packages/vapoursynth.so

--- a/.scripts/vapoursynth-install.sh
+++ b/.scripts/vapoursynth-install.sh
@@ -19,7 +19,7 @@ apt-get install -y build-essential autoconf libtool pkg-config python3-pip && pi
 # Install zimg (from source)
 download_and_build https://github.com/sekrit-twc/zimg/archive/release-2.9.3.tar.gz zimg-release-2.9.3
 # Install vapoursynth (from source)
-download_and_build https://github.com/vapoursynth/vapoursynth/archive/2f0a78495608424019b7a85510699ef68d8484c2.tar.gz vapoursynth-R52
+download_and_build https://github.com/vapoursynth/vapoursynth/archive/2f0a78495608424019b7a85510699ef68d8484c2.tar.gz 2f0a78495608424019b7a85510699ef68d8484c2
 # Fix vapoursynth (native) python path
 PYTHON3_LOCAL_LIB_PATH=$(echo /usr/local/lib/python3.*)
 ln -s $PYTHON3_LOCAL_LIB_PATH/site-packages/vapoursynth.so $PYTHON3_LOCAL_LIB_PATH/dist-packages/vapoursynth.so

--- a/.scripts/vapoursynth64-install.ps1
+++ b/.scripts/vapoursynth64-install.ps1
@@ -7,6 +7,6 @@ Invoke-WebRequest https://github.com/vapoursynth/vapoursynth/releases/download/R
 # Show vapoursynth version
 python -c "import vapoursynth; print(vapoursynth.core.version())"
 # Add compiler access to vapoursynth sdk
-echo "VAPOURSYNTH_LIB_DIR=$Env:PYTHON/sdk/lib64"
+echo "VAPOURSYNTH_LIB_DIR=$Env:PYTHON/sdk/lib64" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding utf8    # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
 # Cleanup
 Remove-Item VapourSynth64-Portable-R52.7z

--- a/.scripts/vapoursynth64-install.ps1
+++ b/.scripts/vapoursynth64-install.ps1
@@ -1,12 +1,10 @@
 # Get python home
 $Env:PYTHON = split-path (Get-Command python).Source
-# Load vapoursynth R52
-Invoke-WebRequest https://github.com/vapoursynth/vapoursynth/releases/download/R52/VapourSynth64-Portable-R52.7z -OutFile "VapourSynth64-Portable-R52.7z"
+# Load vapoursynth R47.2
+wget https://github.com/vapoursynth/vapoursynth/releases/download/R47.2/VapourSynth64-Portable-R47.2.7z -Outfile VapourSynth64-Portable-R47.2.7z
 # Extract vapoursynth archive into python
-7z x VapourSynth64-Portable-R52.7z -o"$Env:PYTHON" -y -aos '-xr!7z.*'
+7z x VapourSynth64-Portable-R47.2.7z -o"$Env:PYTHON" -y
 # Show vapoursynth version
 python -c "import vapoursynth; print(vapoursynth.core.version())"
 # Add compiler access to vapoursynth sdk
 echo "VAPOURSYNTH_LIB_DIR=$Env:PYTHON/sdk/lib64" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding utf8    # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-# Cleanup
-Remove-Item VapourSynth64-Portable-R52.7z

--- a/.scripts/vapoursynth64-install.ps1
+++ b/.scripts/vapoursynth64-install.ps1
@@ -1,10 +1,12 @@
 # Get python home
 $Env:PYTHON = split-path (Get-Command python).Source
 # Load vapoursynth R52
-wget https://github.com/vapoursynth/vapoursynth/releases/download/R52/VapourSynth64-Portable-R52.7z -Outfile VapourSynth64-Portable-R52.7z
+curl -o VapourSynth64-Portable-R52.7z -LJO https://github.com/vapoursynth/vapoursynth/releases/download/R52/VapourSynth64-Portable-R52.7z
 # Extract vapoursynth archive into python
-7z x VapourSynth64-Portable-R52.7z -o"$Env:PYTHON" -y
+7z x VapourSynth64-Portable-R52.7z -o"$Env:PYTHON" -y '-xr!7z.*'
 # Show vapoursynth version
 python -c "import vapoursynth; print(vapoursynth.core.version())"
 # Add compiler access to vapoursynth sdk
-echo "VAPOURSYNTH_LIB_DIR=$Env:PYTHON/sdk/lib64" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding utf8    # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+echo "VAPOURSYNTH_LIB_DIR=$Env:PYTHON/sdk/lib64"
+# Cleanup
+Remove-Item VapourSynth64-Portable-R52.7z

--- a/.scripts/vapoursynth64-install.ps1
+++ b/.scripts/vapoursynth64-install.ps1
@@ -1,7 +1,7 @@
 # Get python home
 $Env:PYTHON = split-path (Get-Command python).Source
 # Load vapoursynth R52
-Invoke-WebRequest https://github.com/vapoursynth/vapoursynth/releases/download/R52/VapourSynth64-Portable-R52.7z
+Invoke-WebRequest https://github.com/vapoursynth/vapoursynth/releases/download/R52/VapourSynth64-Portable-R52.7z -OutFile "VapourSynth64-Portable-R52.7z"
 # Extract vapoursynth archive into python
 7z x VapourSynth64-Portable-R52.7z -o"$Env:PYTHON" -y '-xr!7z.*'
 # Show vapoursynth version
@@ -9,4 +9,4 @@ python -c "import vapoursynth; print(vapoursynth.core.version())"
 # Add compiler access to vapoursynth sdk
 echo "VAPOURSYNTH_LIB_DIR=$Env:PYTHON/sdk/lib64"
 # Cleanup
-# Remove-Item VapourSynth64-Portable-R52.7z
+Remove-Item VapourSynth64-Portable-R52.7z

--- a/.scripts/vapoursynth64-install.ps1
+++ b/.scripts/vapoursynth64-install.ps1
@@ -1,7 +1,7 @@
 # Get python home
 $Env:PYTHON = split-path (Get-Command python).Source
 # Load vapoursynth R52
-curl -o VapourSynth64-Portable-R52.7z -LJO https://github.com/vapoursynth/vapoursynth/releases/download/R52/VapourSynth64-Portable-R52.7z
+Invoke-WebRequest https://github.com/vapoursynth/vapoursynth/releases/download/R52/VapourSynth64-Portable-R52.7z
 # Extract vapoursynth archive into python
 7z x VapourSynth64-Portable-R52.7z -o"$Env:PYTHON" -y '-xr!7z.*'
 # Show vapoursynth version
@@ -9,4 +9,4 @@ python -c "import vapoursynth; print(vapoursynth.core.version())"
 # Add compiler access to vapoursynth sdk
 echo "VAPOURSYNTH_LIB_DIR=$Env:PYTHON/sdk/lib64"
 # Cleanup
-Remove-Item VapourSynth64-Portable-R52.7z
+# Remove-Item VapourSynth64-Portable-R52.7z


### PR DESCRIPTION
# Purpose
This PR updates PowerShell script used for pipeline and/or environment setup.

# Changes
- `vapoursynth64-install.ps1` now uses `Invoke-WebRequest`, since PowerShell 5 (and up), `curl` points to actual `curl.exe` and not `Invoke-WebRequest`. Using `Invoke-WebRequest` _explicitly_ ensures more shells may run the script successfully.

- 7z extract command will now excludes `7z.exe` and `7z.dll` files inside `VapourSynth64-Portable-R52.7z` archive. I used [miniconda3](https://docs.conda.io/en/latest/miniconda.html) to install Python and its tools. However miniconda3 includes 7z executable file by default and expose itself in PATH (same folder with its bundled Python version), which cause an error after extraction (`7z.exe` in 7z file attempts to replace __running__ `7z.exe` in miniconda directory).

- Cleanup after extraction and gitignore minor additions.

# Checklist
- [x] Followed contributing guidelines
- [x] Guaranteed appropriate quality of code
- [ ] Updated documentation (?)
- [x] Successfully tested
- [x] Self-reviewed changes